### PR TITLE
Refactor effect system

### DIFF
--- a/src/engine/platform/mixer.cpp
+++ b/src/engine/platform/mixer.cpp
@@ -48,7 +48,7 @@ struct AudioStruct {
 } audio_struct = {};
 
 void Channel::effect(u32 start, u32 len) {
-    if (delay.active) {
+    if (delay) {
         if (delay.len_seconds != delay._prev_len_seconds) {
             //TODO(GS) crackling when length is changed while sound is playing
             delay.len = (u32) AUDIO_SAMPLE_RATE * delay.len_seconds * 2;
@@ -63,7 +63,6 @@ void Channel::effect(u32 start, u32 len) {
 }
 
 void Channel::set_delay(f32 feedback, f32 len_seconds) {
-    delay.active = true;
     delay.feedback = feedback;
     delay.len_seconds = len_seconds;
 }

--- a/src/engine/platform/mixer.cpp
+++ b/src/engine/platform/mixer.cpp
@@ -68,9 +68,7 @@ void Channel::set_delay(f32 feedback, f32 len_seconds) {
 }
 
 Channel *fetch_channel(u32 channel_id) {
-    if (channel_id >= NUM_CHANNELS) {
-        return nullptr;
-    }
+    ASSERT(channel_id < NUM_CHANNELS, "Invalid channel");
     return &audio_struct.channels[channel_id];
 }
 

--- a/src/engine/platform/mixer.cpp
+++ b/src/engine/platform/mixer.cpp
@@ -37,10 +37,8 @@ struct AudioStruct {
     SoundSource sources[NUM_SOURCES];
     u16 num_free_sources;
     u16 free_sources[NUM_SOURCES];
-    f32 *channels[NUM_CHANNELS];
+    Channel channels[NUM_CHANNELS];
     u32 sample_index;
-    Effect effects[NUM_CHANNELS][NUM_EFFECTS];
-    u16 num_effects;
     // Position of the listener
     Vec2 position;
     f32 time;
@@ -49,63 +47,32 @@ struct AudioStruct {
     SDL_AudioDeviceID dev;
 } audio_struct = {};
 
-Effect create_delay(f32 feedback, f32 delay_time) {
-    ASSERT(delay_time < CHANNEL_BUFFER_LENGTH_SECONDS, "Delay time is longer than channel buffer");
-    auto delay_func = [] (Effect *effect, f32 *buffer, u32 start, u32 len) -> void {
-        if (effect->delay.delay_len_seconds != effect->delay._prev_delay_len_seconds) {
+void Channel::effect(u32 start, u32 len) {
+    if (delay.active) {
+        if (delay.len_seconds != delay._prev_len_seconds) {
             //TODO(GS) crackling when length is changed while sound is playing
-            effect->delay.delay_len = (u32) AUDIO_SAMPLE_RATE * effect->delay.delay_len_seconds * 2;
-            effect->delay._prev_delay_len_seconds = effect->delay.delay_len_seconds;
+            delay.len = (u32) AUDIO_SAMPLE_RATE * delay.len_seconds * 2;
+            delay._prev_len_seconds = delay.len_seconds;
         }
         for (u32 i = 0; i < len; i++) {
             u32 cur_pos = (start + i) % CHANNEL_BUFFER_LENGTH;
-            u32 prev_pos = (start + i - effect->delay.delay_len + CHANNEL_BUFFER_LENGTH) % CHANNEL_BUFFER_LENGTH;
-            buffer[cur_pos] += buffer[prev_pos] * effect->delay.feedback;
+            u32 pre_pos = (start + i - delay.len + CHANNEL_BUFFER_LENGTH) % CHANNEL_BUFFER_LENGTH;
+            buffer[cur_pos] += buffer[pre_pos] * delay.feedback;
         }
-    };
-    Effect effect = {};
-    effect.id = invalid_id();
-    effect.effect = delay_func;
-    effect.delay.feedback = feedback;
-    effect.delay.delay_len_seconds = delay_time;
-    return effect;
-}
-
-EffectID add_effect(Effect effect, u32 channel) {
-    ASSERT(channel < NUM_CHANNELS, "Invalid channel");
-    for (u32 i = 0; i < NUM_EFFECTS; i++) {
-        if (audio_struct.effects[channel][i].effect) continue;
-        EffectID id = {(s32) channel, i, audio_struct.num_effects};
-        effect.id = id;
-        audio_struct.effects[effect.id.channel][effect.id.slot] = effect;
-        audio_struct.num_effects++;
-        return effect.id;
     }
-    ERR("Not enough free effect slots on channel %d, skipping effect", channel);
-    return invalid_id();
 }
 
-Effect *fetch_effect(EffectID id) {
-    if (!audio_struct.effects[id.channel][id.slot].effect) {
+void Channel::set_delay(f32 feedback, f32 len_seconds) {
+    delay.active = true;
+    delay.feedback = feedback;
+    delay.len_seconds = len_seconds;
+}
+
+Channel *fetch_channel(u32 channel_id) {
+    if (channel_id >= NUM_CHANNELS) {
         return nullptr;
     }
-    return &audio_struct.effects[id.channel][id.slot];
-}
-
-bool remove_effect(EffectID id) {
-    if (!audio_struct.effects[id.channel][id.slot].effect) {
-        ERR("Invalid EffectID");
-        return false;
-    }
-    audio_struct.effects[id.channel][id.slot].effect = nullptr;
-    return true;
-}
-
-void clear_effects(u32 channel) {
-    ASSERT(channel < NUM_CHANNELS, "Invalid channel");
-    for (u32 i = 0; i < NUM_EFFECTS; i++) {
-        audio_struct.effects[channel][i].effect = nullptr;
-    }
+    return &audio_struct.channels[channel_id];
 }
 
 f32 pitch(s32 tone) {
@@ -140,17 +107,17 @@ AudioID push_sound(SoundSource source) {
     return {0, NUM_SOURCES};
 }
 
-AudioID play_sound(u32 channel, AssetID asset_id, f32 pitch, f32 gain, f32 pitch_variance,
+AudioID play_sound(u32 channel_id, AssetID asset_id, f32 pitch, f32 gain, f32 pitch_variance,
                    f32 gain_variance, bool loop) {
-    ASSERT(channel < NUM_CHANNELS, "Invalid channel");
-    return push_sound({0, asset_id, channel, pitch + random_real(-1, 1) * pitch_variance,
+    ASSERT(channel_id < NUM_CHANNELS, "Invalid channel");
+    return push_sound({0, asset_id, channel_id, pitch + random_real(-1, 1) * pitch_variance,
                        gain + random_real(-1, 1) * gain_variance, loop});
 }
 
-AudioID play_sound_at(u32 channel, AssetID asset_id, Vec2 position, f32 pitch, f32 gain,
+AudioID play_sound_at(u32 channel_id, AssetID asset_id, Vec2 position, f32 pitch, f32 gain,
                       f32 pitch_variance, f32 gain_variance, bool loop) {
-    ASSERT(channel < NUM_CHANNELS, "Invalid channel");
-    return push_sound({0, asset_id, channel, pitch + random_real(-1, 1) * pitch_variance,
+    ASSERT(channel_id < NUM_CHANNELS, "Invalid channel");
+    return push_sound({0, asset_id, channel_id, pitch + random_real(-1, 1) * pitch_variance,
                        gain + random_real(-1, 1) * gain_variance, loop, true,
                        position});
 }
@@ -187,9 +154,9 @@ void audio_callback(void* userdata, u8* stream, int len) {
     const f32 TIME_STEP = data->time_step;
 
     u32 base = audio_struct.sample_index;
-    for (u32 channel = 0; channel < NUM_CHANNELS; channel++) {
+    for (u32 channel_id = 0; channel_id < NUM_CHANNELS; channel_id++) {
         for (u32 i = 0; i < SAMPLES; i++)
-            audio_struct.channels[channel][(base + i) % CHANNEL_BUFFER_LENGTH] = 0.0;
+            audio_struct.channels[channel_id].buffer[(base + i) % CHANNEL_BUFFER_LENGTH] = 0.0;
     }
 
     START_PERF(AUDIO_SOURCES);
@@ -264,8 +231,8 @@ void audio_callback(void* userdata, u8* stream, int len) {
                 }
             }
             u32 sample_index = (audio_struct.sample_index + i) % CHANNEL_BUFFER_LENGTH;
-            audio_struct.channels[source->channel][sample_index+0] += left;
-            audio_struct.channels[source->channel][sample_index+1] += right;
+            audio_struct.channels[source->channel].buffer[sample_index+0] += left;
+            audio_struct.channels[source->channel].buffer[sample_index+1] += right;
         }
     }
     STOP_PERF(AUDIO_SOURCES);
@@ -274,16 +241,10 @@ void audio_callback(void* userdata, u8* stream, int len) {
 
     START_PERF(AUDIO_EFFECTS);
     for (u32 channel_id = 0; channel_id < NUM_CHANNELS; channel_id++) {
-        f32 *channel = audio_struct.channels[channel_id];
-
-        for (u32 i = 0; i < NUM_EFFECTS; i++) {
-            Effect *effect = &audio_struct.effects[channel_id][i];
-            if (!effect->effect) continue;
-            effect->effect(effect, channel, base, SAMPLES);
-        }
-
+        Channel *channel = &audio_struct.channels[channel_id];
+        channel->effect(base, SAMPLES);
         for (u32 i = 0; i < SAMPLES; i++) {
-            output_stream[i] += channel[(base + i) % CHANNEL_BUFFER_LENGTH];
+            output_stream[i] += channel->buffer[(base + i) % CHANNEL_BUFFER_LENGTH];
         }
     }
     STOP_PERF(AUDIO_EFFECTS);
@@ -299,7 +260,7 @@ bool init() {
         audio_struct.free_sources[i] = i;
 
     for (u32 i = 0; i < NUM_CHANNELS; i++)
-        audio_struct.channels[i] = audio_mixer.arena->push<f32>(CHANNEL_BUFFER_LENGTH);
+        audio_struct.channels[i].buffer = audio_mixer.arena->push<f32>(CHANNEL_BUFFER_LENGTH);
 
     SDL_AudioSpec want = {};
     want.freq = AUDIO_SAMPLE_RATE;

--- a/src/engine/platform/mixer.h
+++ b/src/engine/platform/mixer.h
@@ -73,7 +73,7 @@ bool init();
 // Plays a sound in the game world, the sound should have been
 // loaded by the asset system:<br>
 // <ul>
-//  <li>channel, which channel the sound should be sent too.</li>
+//  <li>channel_id, which channel the sound should be sent too.</li>
 //  <li>asset_id, the sound asset to play.</li>
 //  <li>pitch, how fast the sound should be played.</li>
 //  <li>gain, how loud the sound should be played.</li>
@@ -81,7 +81,7 @@ bool init();
 //  <li>gain_variance, how much random variance there should be applied to the gain.</li>
 //  <li>loop, if the sound should loop or not.</li>
 // </ul>
-AudioID play_sound(u32 channel, AssetID asset_id,
+AudioID play_sound(u32 channel_id, AssetID asset_id,
                    f32 pitch = 1.0,
                    f32 gain = AUDIO_DEFAULT_GAIN,
                    f32 pitch_variance = AUDIO_DEFAULT_VARIANCE,
@@ -93,7 +93,7 @@ AudioID play_sound(u32 channel, AssetID asset_id,
 // has applied distance attenuation. The sound
 // should have been loaded by the asset system:<br>
 // <ul>
-//  <li>channel, which channel the sound should be sent too.</li>
+//  <li>channel_id, which channel the sound should be sent too.</li>
 //  <li>asset_id, the sound asset to play.</li>
 //  <li>position, where in the game world the sound should come from.</li>
 //  <li>pitch, how fast the sound should be played.</li>
@@ -102,7 +102,7 @@ AudioID play_sound(u32 channel, AssetID asset_id,
 //  <li>gain_variance, how much random variance there should be applied to the gain.</li>
 //  <li>loop, if the sound should loop or not.</li>
 // </ul>
-AudioID play_sound_at(u32 channel, AssetID asset_id,
+AudioID play_sound_at(u32 channel_id, AssetID asset_id,
                       Vec2 position, f32 pitch = 1.0,
                       f32 gain = AUDIO_DEFAULT_GAIN,
                       f32 pitch_variance = AUDIO_DEFAULT_VARIANCE,
@@ -116,28 +116,13 @@ void stop_sound(AudioID id);
 #ifdef _COMMENTS_
 
 ///*
-// Attaches an effect to the specified channel and returns a unique ID to the
-// effect.
-EffectID add_effect(Effect effect, u32 channel);
+// Returns a pointer to a channel. Returns nullptr if the channel_id isn't
+// valid.
+Channel *fetch_channel(u32 channel_id);
 
 ///*
-// Returns a delay-effect where feedback is the amount of sound to be repeated
-// and delay_time is the time in seconds between each repeat.
-Effect create_delay(f32 feedback, f32 delay_time);
-
-///*
-// Fetches a pointer to an effect with an id. Returns nullptr if the effect
-// isn't valid, which usually means that the effect has been detached.
-Effect *fetch_effect(EffectID id);
-
-///*
-// Detaches an effect from its channel. Returns true if the effect was
-// successfully detached, otherwise false.
-bool remove_effect(EffectID id);
-
-///*
-// Detaches all effects from a channel.
-void clear_effects(u32 channel);
+// Activates delay on the channel with the specified settings.
+void Channel::set_delay(f32 feedback, f32 len_seconds);
 
 #endif
 

--- a/src/engine/platform/mixer.h
+++ b/src/engine/platform/mixer.h
@@ -36,11 +36,13 @@ struct Channel {
     f32 *buffer;
 
     struct {
-        bool active;
         f32 feedback;
         u32 len;
         f32 len_seconds;
         f32 _prev_len_seconds;
+        operator bool() const {
+            return len_seconds > 0;
+        }
     } delay = {};
     void set_delay(f32 feedback, f32 len_seconds);
     void remove_delay();

--- a/src/engine/platform/mixer.h
+++ b/src/engine/platform/mixer.h
@@ -32,39 +32,23 @@ struct AudioID {
     u16 slot;
 };
 
-struct EffectID {
-    s32 channel;
-    u32 slot;
-    u32 gen;
+struct Channel {
+    f32 *buffer;
 
-    bool operator== (const EffectID &other) const {
-        return channel == other.channel && slot == other.slot && gen == other.gen;
-    }
+    struct {
+        bool active;
+        f32 feedback;
+        u32 len;
+        f32 len_seconds;
+        f32 _prev_len_seconds;
+    } delay = {};
+    void set_delay(f32 feedback, f32 len_seconds);
+    void remove_delay();
 
-    operator bool() const {
-        return channel >= 0;
-    }
+    void effect(u32 start, u32 len);
 };
 
-EffectID invalid_id() {
-    return {-1, 0, 0};
-}
-
-//TODO(GS) standard effects for common sounds (consts).
-struct Effect {
-    EffectID id;
-    void (* effect)(Effect *effect, f32 *buffer, u32 start, u32 len);
-    union {
-        struct {
-            f32 feedback;
-            u32 delay_len;
-            f32 delay_len_seconds;
-            f32 _prev_delay_len_seconds;
-        } delay;
-    };
-};
-
-Effect create_delay(f32 feedback, f32 delay_time);
+// TODO(GS) standard effects for common sounds (consts).
 
 // TODO(ed): Some reverb and echo effects would
 // go a long way to create cool atmospheres.

--- a/src/examples/mixer.cpp
+++ b/src/examples/mixer.cpp
@@ -15,17 +15,15 @@ Mixer::play_sound(0, ASSET_MY_SOUND_FILE);
 // This line will play an omnipresent audio source on channel 0 that can be
 // heard unrelated to where the camera is placed in the game world.
 
-//// Adding effects
-// Adding effects is voluntary but simple. You need to 1) create the effect and
-// 2) attach it to the correct channel. Let's begin by creating the effect.
-Mixer::Effect delay = Mixer::create_delay(0.3, 0.2);
-// This delay has a feedback of 0.3 and length of 0.2 seconds, which means that
-// every sound played is played again 0.2 seconds later but with only 30% of
-// the original volume.
-Mixer::EffectID delay_id = Mixer::add_effect(delay, 0);
-// <p>This will attach the delay to channel 0.</p>
-// <p>Most of the time you'd probably do this inline, like so:</p>
-Mixer::EffectID delay_id = Mixer::add_effect(Mixer::create_delay(0.3, 0.2), 0);
-// The parameters can be edited at any time, even when sound is playing.
-Effect *effect = Mixer::fetch_effect(delay_id);
-effect->delay.feedback = 0.5;
+//// Channels and effects
+// Every sound is played on a channel. Effects can be enabled on specific
+// channels, so sound A can be played with delay at the same time as sound B
+// which is played without delay.
+Mixer::fetch_channel(0)->set_delay(0.3, 0.2);
+// <p>This will activate a delay on channel 0 with a feedback of 0.3 and length of
+// 0.2 seconds, which means that every sound played is played again 0.2 seconds
+// later with only 30% of the original volume.</p>
+// <p>The delay can then be de-activated at a later point in time.</p>
+Mixer::fetch_channel(0)->delay.active = false;
+// The effect-parameters can also be changed at any time.
+Mixer::fetch_channel(0)->delay.feedback = 0.5;

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -56,7 +56,7 @@ void entity_registration() {
 
 Renderer::Camera to;
 Renderer::Camera from;
-Mixer::EffectID delay_id;
+Mixer::Channel *channel;
 void setup() {
     using namespace Input;
     add(K(a), Name::LEFT);
@@ -92,9 +92,8 @@ void setup() {
         to = Renderer::camera_fit(LEN(points), points, 0.0);
         from = *Renderer::get_camera();
     }
-
-    Mixer::Effect delay = Mixer::create_delay(0.3, 0.2);
-    delay_id = Mixer::add_effect(delay, 1);
+    channel = Mixer::fetch_channel(1);
+    channel->set_delay(0.3, 0.2);
 }
 
 // Main logic
@@ -120,8 +119,8 @@ void update(f32 delta) {
     static Span span = { 0.3, 0.35};
     if (Util::begin_tweak_section("Other tweaks", &show_various_tweaks)) {
         Util::tweak("point size", &span, 0.1);
-        //Util::tweak("delay length", &delay->delay._delay_len_seconds);
-        //Util::tweak("delay feedback", &delay->delay.feedback, 0.5);
+        Util::tweak("delay length", &channel->delay.len_seconds);
+        Util::tweak("delay feedback", &channel->delay.feedback, 0.5);
     }
     Util::end_tweak_section(&show_various_tweaks);
 


### PR DESCRIPTION
The effect system has been refactored to work more like the particle system. Instead of having every effect be an object with some sort of inner function and lots of boiler-plate that looks the same for every additional effect, a single copy of every effect is now attached to every channel.