### PR TITLE
Add namespace Fog wrapping most of unix_main.cpp

### DIFF
--- a/src/engine/unix_main.cpp
+++ b/src/engine/unix_main.cpp
@@ -109,6 +109,8 @@ u64 Perf::highp_now() {
     return (tp.tv_sec * 1000000000 + tp.tv_nsec) / 1000;
 }
 
+namespace Fog {
+
 #ifdef DEBUG
 void register_debug_keybinds() {
     using namespace Input;
@@ -339,6 +341,8 @@ void run(FogCallback user_update, FogCallback user_draw) {
 
     _fog_close_app_responsibly();
 }
+
+}  // namespace Fog
 
 void _fog_close_app_responsibly() {
     Mixer::deinit();

--- a/tools/bind-gen.py
+++ b/tools/bind-gen.py
@@ -133,7 +133,7 @@ def find_func_name(definition, namespace):
 
 def gen_new_name(name, namespace):
     if namespace:
-        return GLOBAL_NAMESPACE + namespace.lower() + "_" + name.replace("*", "")
+        return GLOBAL_NAMESPACE + (namespace.lower() + "_" if namespace.lower() != "fog" else "") + name.replace("*", "")
     return GLOBAL_NAMESPACE + name.replace("*", "")
 
 def format_function_def(namespace, definition):
@@ -279,7 +279,7 @@ if __name__ == "__main__":
             f.write("\n".join(bodies))
             f.write("\n#undef FOG_IMPORT")
         with open("out/fog.h", "w") as f:
-            f.write("#pragma once")
+            f.write("#pragma once\n")
             f.write(preamble)
             f.write("#include <stdint.h>\n")
             f.write("#include <stdarg.h>\n")


### PR DESCRIPTION
The wrapped methods used to be included in libfog.lib as e.g. draw() and
update() directly, making games written in C++ unable to name a function
draw(), update() and so on. With this they're only reachable with a
`fog_`-prefix when compiling with C and, additionally, in the
`Fog::`-namespace when compiling with C++, which is more reasonable.

The change in bind-gen is to avoid functions named stuff like
`fog_fog_run`.