### PR TITLE
Add optional modifier to input_add

### DIFF
--- a/src/engine/platform/input.cpp
+++ b/src/engine/platform/input.cpp
@@ -32,7 +32,7 @@ void insert(Binding binding) {
     global_mapping.used_bindings += 1;
 }
 
-b8 add(InputCode code, Name name, Player player) {
+b8 add_mod(InputCode code, Name name, Player player, f32 modifier) {
     Binding binding = {code, player, name, 0};
 
     // Check if there is a free binding.
@@ -43,7 +43,7 @@ b8 add(InputCode code, Name name, Player player) {
     for (u32 i = 0; i < NUM_ALTERNATIVE_BINDINGS; i++) {
         if (buttons[index + i].is_used()) continue;
         binding.binding_id = i;
-        buttons[index + i].reset(name);
+        buttons[index + i].reset(name, modifier);
         valid = true;
         break;
     }
@@ -135,7 +135,7 @@ b8 using_controller() {
 }
 
 #define BEGIN_BINDINGS_BLOCK                                 \
-    if (global_mapping.text_input) return false;               \
+    if (global_mapping.text_input) return false;             \
     for (u32 p = 0; p < (u32) Player::NUM; p++) {            \
         Player p_mask = Player(1 << p);                      \
         if (!is(player, p_mask)) continue;                   \
@@ -201,7 +201,7 @@ f32 value(Name name, Player player) {
     BEGIN_BINDINGS_BLOCK {
         if (!button.is_down()) continue;
         num_down++;
-        value += button.value;
+        value += button.value * button.modifier;
     }
     END_BINDINGS_BLOCK
     if (num_down) return value / num_down;

--- a/src/engine/platform/input.h
+++ b/src/engine/platform/input.h
@@ -101,6 +101,7 @@ struct Binding {
     Player player;
     Name name;
     u8 binding_id;
+    s32 inverted;
 
     b8 operator==(InputCode &other) const {
         return name != NO_INPUT && code == other;
@@ -136,6 +137,7 @@ struct Mapping {
 
     struct VirtualButton {
         Name name;
+        f32 modifier;
         ButtonState state;
         f32 value;
 
@@ -144,7 +146,7 @@ struct Mapping {
             state = v ? ButtonState::PRESSED : ButtonState::RELEASED;
         }
 
-        void reset(Name name) { *this = {name}; }
+        void reset(Name name, f32 modifier) { *this = {name, modifier}; }
         b8 is_down() { return (u32)state & (u32)ButtonState::DOWN; }
         b8 is_used() { return name != NO_INPUT; }
     };
@@ -223,12 +225,20 @@ void type_text(const char *string);
 // is changed.
 b8 edit_string(char *text, u32 max_length);
 
-///* add
-// Register a new mapping to the input system.<br>
-// code, the keycode, should be recived from calling K(DESIRED_KEY), DESIRED_KEY
-// should be lowercase letters for normal keys and UPPERCASE for special keys.
+///*
+// Register a new mapping to the input system.
+// The value returned from value(...) is multiplied with modifier.
 // Player, the player that has this binding, can be P1, P2, P3, P4.
-b8 add(InputCode code, Name name, Player player=P1);
+b8 add_mod(InputCode code, Name name, Player player, f32 modifier);
+
+///*
+// Register a new mapping to the input system.
+// Player, the player that has this binding, can be P1, P2, P3, P4.
+b8 add(InputCode code, Name name, Player player);
+
+b8 add(InputCode code, Name name, Player player=P1) {
+    return add_mod(code, name, player, 1.0f);
+}
 
 ///*
 // Returns true if the input button, stick or key was pressed or released this frame.

--- a/src/engine/platform/input.h
+++ b/src/engine/platform/input.h
@@ -101,7 +101,6 @@ struct Binding {
     Player player;
     Name name;
     u8 binding_id;
-    s32 inverted;
 
     b8 operator==(InputCode &other) const {
         return name != NO_INPUT && code == other;


### PR DESCRIPTION
Usage example:
```c
fog_input_add(fog_axis_to_input_code(SDL_CONTROLLER_AXIS_LEFTY, 0), NAME(UPDOWN), P1);
fog_input_add(fog_axis_to_input_code(SDL_CONTROLLER_AXIS_LEFTX, 0), NAME(LEFTRIGHT), P1);

fog_input_add_mod(fog_key_to_input_code(SDLK_w), NAME(UPDOWN), P1, +1);
fog_input_add_mod(fog_key_to_input_code(SDLK_s), NAME(UPDOWN), P1, -1);
fog_input_add_mod(fog_key_to_input_code(SDLK_d), NAME(LEFTRIGHT), P1, +1);
fog_input_add_mod(fog_key_to_input_code(SDLK_a), NAME(LEFTRIGHT), P1, -1);
```

In this example, calling `fog_input_value(NAME(UPDOWN), P1)` is enough to support both controller and keyboard.

`fog_input_add(...)` still works as it used to.